### PR TITLE
Implement payloads for state transitions

### DIFF
--- a/src/main/java/EventExperiment.java
+++ b/src/main/java/EventExperiment.java
@@ -16,7 +16,7 @@ public class EventExperiment {
             addState(new State.Builder(EVEN_STATE)
                     .withEntry(() -> System.out.println("Entering EVEN"))
                     .withEvent(AddEvent.class,
-                            ae -> {if (ae.amountToAdd % 2 == 1) { gotoState(ODD_STATE); throw new RuntimeException("Should be dead code!"); } })
+                            ae -> { if (ae.amountToAdd % 2 == 1) gotoState(ODD_STATE); })
                     .withExit(() -> System.out.println("Leaving EVEN"))
                     .build());
 
@@ -24,9 +24,9 @@ public class EventExperiment {
                     .isInitialState(true)
                     .withEntry(() -> System.out.println("Entering ODD"))
                     .withEvent(AddEvent.class,
-                            ae -> {if (ae.amountToAdd % 2 == 1) { gotoState(EVEN_STATE); throw new RuntimeException("Should be dead code!"); } })
+                            ae -> { if (ae.amountToAdd % 2 == 1) gotoState(EVEN_STATE); })
                     .withEvent(MulEvent.class,
-                            me -> {if (me.amountToMul % 2 == 0) { gotoState(EVEN_STATE); throw new RuntimeException("Should be dead code!"); } })
+                            me -> { if (me.amountToMul % 2 == 0) gotoState(EVEN_STATE); })
                     .withExit(() -> System.out.println("Leaving ODD"))
                     .build());
         }

--- a/src/main/java/GotoPayloadClassException.java
+++ b/src/main/java/GotoPayloadClassException.java
@@ -1,0 +1,19 @@
+/**
+ * Thrown when the Monitor tries to pass a state transition payload of the wrong type to
+ * the entry handler for a new state.
+ */
+public class GotoPayloadClassException extends RuntimeException {
+    private Class<?> payloadClazz;
+    private State s;
+
+    public <P> GotoPayloadClassException(P payload, State s) {
+        this.payloadClazz = payload.getClass();
+        this.s = s;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format("Got invalid payload of type %s for state %s's onEntry handler.",
+                payloadClazz.getName(), s.getKey());
+    }
+}

--- a/src/main/java/TransitionException.java
+++ b/src/main/java/TransitionException.java
@@ -1,3 +1,6 @@
+import java.util.Objects;
+import java.util.Optional;
+
 /**
  * A TransitionException is raised by user handlers when they would like to transition
  * to a new state.
@@ -9,12 +12,28 @@
  */
 public class TransitionException extends Exception {
     private State targetState;
+    private Optional<Object> payload;
 
     public State getTargetState() {
         return targetState;
     }
 
+    public Optional<Object> getPayload() {
+        return payload;
+    }
+
     public TransitionException(State s) {
+        Objects.requireNonNull(s);
+
         this.targetState = s;
+        this.payload = Optional.empty();
+    }
+
+    public TransitionException(State s, Object payload) {
+        Objects.requireNonNull(s);
+        Objects.requireNonNull(payload);
+
+        this.targetState = s;
+        this.payload = Optional.of(payload);
     }
 }


### PR DESCRIPTION
Now, entry handlers (may) take an argument holding a payload passed to the
runtime through `gotoState()`.

There are a few sharp corners here which I don't like: in particular, because
we can't guarantee that all payloads will be of the same type, we have to defer
to runtime type checking - in other words, an ill-typed entry handler could
throw an exception.  Additionally, because not every goto takes a payload,
currently the argument can potentially be null.  I might change this depending
on what folks think - it could take an Optional<T> rather than a T; it's more
verbose but safer.