### PR TITLE
Added check to determine running state

### DIFF
--- a/src/main/java/prt/Monitor.java
+++ b/src/main/java/prt/Monitor.java
@@ -202,6 +202,9 @@ public class Monitor {
     }
 
     private <P> void readyImpl(Optional<P> payload) {
+        if (isRunning)
+            throw new RuntimeException("prt.Monitor is already running.");
+
         isRunning = true;
 
         State s = startState.orElseThrow(() ->


### PR DESCRIPTION
I wasn't sure if `null` should be returned here, so I threw an exception instead. This satisfies the conditions of issue #32.